### PR TITLE
Fixed the way the announcements are set up in Train Model/Controller

### DIFF
--- a/src/Train/TrainController/train_controller_backend.py
+++ b/src/Train/TrainController/train_controller_backend.py
@@ -164,23 +164,26 @@ class TrainController(QMainWindow):
         #   - The train’s speed has reached zero.
         # print(self.current_block.id)
         # print(self.current_block.station)
+        
+        # Extract station information from the track data
+        station = self.track_data.stations.get(self.current_block.id, None)
+        
         if (self.wayside_authority > 300 and self.previous_authority < 300 and self.current_block.station and not self.dwell):
             print("Stopping at station...")
 
-            # TODO: Announcements
             # set the next station announcement based on station information
-            station = self.track_data.stations.get(self.current_block.id, None)
             if station:
                 # update the next_station field to the station's name
                 self.next_station = station.name
-            else:
-                # arbitrary station name
-                self.next_station = "Unknown Station"
 
             # Mark that we are in the stopping/dwell process
             self.stopping = True
             # Call start_dwell after a short delay (to let the stopping process complete)
             QTimer.singleShot(int(500 / self.global_clock.time_multiplier), self.start_dwell)
+            
+        # if we are not at a station, reset the next station announcement
+        if not station: 
+            self.next_station = ""
 
         self.previous_authority = self.wayside_authority
  

--- a/src/Train/TrainController/train_controller_frontend.py
+++ b/src/Train/TrainController/train_controller_frontend.py
@@ -214,10 +214,7 @@ class TrainControllerFrontend(QMainWindow):
         self.display_next_station()
 
     def display_next_station(self):
-        if self.current_train.actual_speed > 0:
-            self.ui.next_station_label.setText("")
-        else:
-            self.ui.next_station_label.setText(self.current_train.next_station)
+        self.ui.next_station_label.setText(self.current_train.next_station)
 
     def activate_service_brake(self):
         self.ui.service_brake_on_light.setStyleSheet("background-color: yellow; font-weight: bold; font-size: 16px;")

--- a/src/Train/TrainModel/train_model_frontend.py
+++ b/src/Train/TrainModel/train_model_frontend.py
@@ -223,14 +223,9 @@ class TrainModelFrontEnd(QMainWindow):
             self.train_ui.button_emergency.setEnabled(not self.current_train.emergency_brake)
             self.train_ui.button_emergency.setChecked(self.current_train.emergency_brake)
             
-            # --- Announcement Display Logic ---
-            # Get the station name from the backend announcement field.
-            if self.current_train.announcement and self.current_train.actual_speed <= 0.1:
-                self.train_ui.Announcement_2.setText(f"Arrived at {self.current_train.announcement}")
+            if hasattr(self.train_ui, "Announcement_2"):
+                self.train_ui.Announcement_2.setText(self.current_train.announcement)
                 self.train_ui.Announcement_2.setStyleSheet("font-size: 20px; font-weight: bold;")
-            else:
-                # Clear the announcement when the train moves.
-                self.train_ui.Announcement_2.setText("")
 
             if hasattr(self.train_ui, "Temperature"):
                 display_temp = self.current_train.actual_temperature * 9 / 5 + 32


### PR DESCRIPTION
Fixed the way the announcements are set up in Train Model/Controller (announcement would pop up when the brakes were hit)