### PR TITLE
Wayside clamps

### DIFF
--- a/src/Track/TrackModel/track_model_backend.py
+++ b/src/Track/TrackModel/track_model_backend.py
@@ -145,8 +145,19 @@ class Train:
                     return
                 self.current_block = self.track_data.blocks[int(self.current_block.id[1:])+(self.travel_direction*2-1)-1]
             
-            # Set new block to occupied
-            self.dynamic_track.occupancies[self.current_block.id]=Occupancy.OCCUPIED
+            # check if new block is occupied (i.e. a crash occurs)
+            if self.dynamic_track.occupancies[self.current_block.id]==Occupancy.OCCUPIED:
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+                print("TRAIN CRASH FROM OCCUPANCIES")
+            else:
+                # Set new block to occupied
+                self.dynamic_track.occupancies[self.current_block.id]=Occupancy.OCCUPIED
 
             # Check for beacon data in new block, if its there, send to train model
             if self.track_data.blocks[int(self.current_block.id[1:])-1].beacon:

--- a/src/Track/TrackModel/track_model_backend.py
+++ b/src/Track/TrackModel/track_model_backend.py
@@ -342,8 +342,7 @@ class TrackModel(QtWidgets.QMainWindow):
             if train.current_block.id in wayside_authorities:
                 send_to_train["wayside_authority"]=wayside_authorities[train.current_block.id]
             
-            if len(send_to_train)>0:
-                train.train_model.set_input_data(track_data=send_to_train)
+            train.train_model.set_input_data(track_data=send_to_train)
         for block, maintenance in maintenances.items():
             if maintenance:
                 self.dynamic_track.occupancies[block]=Occupancy.MAINTENANCE

--- a/src/Track/TrackModel/track_model_backend.py
+++ b/src/Track/TrackModel/track_model_backend.py
@@ -337,12 +337,13 @@ class TrackModel(QtWidgets.QMainWindow):
             if train.current_block.id in wayside_speeds:
                 send_to_train["wayside_speed"]=wayside_speeds[train.current_block.id]
             if train.previous_block.id in wayside_authorities:
-                if wayside_authorities[train.previous_block.id] != 0:
+                if wayside_authorities[train.previous_block.id] != 0 or wayside_authorities[train.previous_block.id] != None:
                     send_to_train["wayside_authority"]=wayside_authorities[train.previous_block.id]+train.previous_block.length
             if train.current_block.id in wayside_authorities:
                 send_to_train["wayside_authority"]=wayside_authorities[train.current_block.id]
             
-            train.train_model.set_input_data(track_data=send_to_train)
+            if len(send_to_train) > 0:
+                train.train_model.set_input_data(track_data=send_to_train)
         for block, maintenance in maintenances.items():
             if maintenance:
                 self.dynamic_track.occupancies[block]=Occupancy.MAINTENANCE

--- a/src/Track/TrackModel/track_model_backend.py
+++ b/src/Track/TrackModel/track_model_backend.py
@@ -332,14 +332,16 @@ class TrackModel(QtWidgets.QMainWindow):
     def update_from_comms_outputs(self, wayside_speeds={}, wayside_authorities={}, maintenances={}):
         for train in self.trains:
             send_to_train = {} # conglomerate in this to prevent calling set_input_data multiple times
+            if train.previous_block.id in wayside_speeds:
+                send_to_train["wayside_speed"]=wayside_speeds[train.previous_block.id]
             if train.current_block.id in wayside_speeds:
                 send_to_train["wayside_speed"]=wayside_speeds[train.current_block.id]
-            elif train.previous_block.id in wayside_speeds:
-                send_to_train["wayside_speed"]=wayside_speeds[train.previous_block.id]
+            if train.previous_block.id in wayside_authorities:
+                if wayside_authorities[train.previous_block.id] != 0:
+                    send_to_train["wayside_authority"]=wayside_authorities[train.previous_block.id]+train.previous_block.length
             if train.current_block.id in wayside_authorities:
                 send_to_train["wayside_authority"]=wayside_authorities[train.current_block.id]
-            elif train.previous_block.id in wayside_authorities:
-                send_to_train["wayside_authority"]=wayside_authorities[train.previous_block.id]+train.previous_block.length
+            
             if len(send_to_train)>0:
                 train.train_model.set_input_data(track_data=send_to_train)
         for block, maintenance in maintenances.items():

--- a/src/Track/WaysideController/PLC/green_line_plc_1.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_1.py
@@ -74,6 +74,21 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
     else:
         clamps[52:54] = [False]*len(clamps[52:54])
 
+    #for i, previous in enumerate(previous_occupancies): # for each previous occupancyd
+     #   if i < len(previous_occupancies) - 3:
+      #      if previous and not clamps[i + 1]:
+       #         if block_occupancies[i + 1] and (block_occupancies[i + 2] or block_occupancies[i + 3]):
+        #            clamps[i + 1] = True
+         #   elif clamps[i + 1]:
+          #      if block_occupancies[i + 1] and (block_occupancies[i + 2] or block_occupancies[i + 3]):
+           #         clamps[i + 1] = True
+            #    else:
+             #       clamps[i + 1] = False
+     
+
+
+
+
 
     return switch_positions, light_signals, crossing_signals, clamps
     

--- a/src/Track/WaysideController/PLC/green_line_plc_1.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_1.py
@@ -65,13 +65,13 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
 
     # if the switch position is in the wrong position 13-12 and there is a train in the off section
     if not switch_positions[0] and train_in_a_b_c:
-        clamps[6:12] = [True]*len(clamps[6:12]) # clamp the blocks in c just in case
+        clamps[10:12] = [True]*len(clamps[10:12]) # clamp the blocks in c just in case
     else:
-        clamps[6:12] = [False]*len(clamps[6:12])
+        clamps[10:12] = [False]*len(clamps[10:12])
     # if the switch is in the wrong position 28-29 and there is a train in the section incoming
     if not switch_positions[1] and train_in_y_z:
-        clamps[50:54] = [True]*len(clamps[50:54]) # clamp the blocks in y and z in case
+        clamps[52:54] = [True]*len(clamps[52:54]) # clamp the blocks in y and z in case
     else:
-        clamps[50:54] = [False]*len(clamps[50:54])
+        clamps[52:54] = [False]*len(clamps[52:54])
     return switch_positions, light_signals, crossing_signals, clamps
     

--- a/src/Track/WaysideController/PLC/green_line_plc_1.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_1.py
@@ -65,13 +65,15 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
 
     # if the switch position is in the wrong position 13-12 and there is a train in the off section
     if not switch_positions[0] and train_in_a_b_c:
-        clamps[10:12] = [True]*len(clamps[10:12]) # clamp the blocks in c just in case
+        clamps[0:2] = [True]*len(clamps[0:2]) # clamp the blocks in a just in case
     else:
-        clamps[10:12] = [False]*len(clamps[10:12])
+        clamps[0:2] = [False]*len(clamps[0:2])
     # if the switch is in the wrong position 28-29 and there is a train in the section incoming
     if not switch_positions[1] and train_in_y_z:
-        clamps[52:54] = [True]*len(clamps[52:54]) # clamp the blocks in y and z in case
+        clamps[52:54] = [True]*len(clamps[52:54]) # clamp the blocks in z in case
     else:
         clamps[52:54] = [False]*len(clamps[52:54])
+
+
     return switch_positions, light_signals, crossing_signals, clamps
     

--- a/src/Track/WaysideController/PLC/green_line_plc_1.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_1.py
@@ -1,4 +1,4 @@
-def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signals, previous_occupancies, exit_blocks):
+def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signals, previous_occupancies, exit_blocks, clamps):
     """
     User-defined logic for controlling track switches, lights, and crossing signals.
 
@@ -32,6 +32,8 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
         - True for exit blocks indicates: SELECTED
         - False for exit blocks indicates: NOT SELECTED
     
+    :param clamps: a list of booleans where true indicates the block should be clamped
+
     :returns switch_positions, light_signals, light_signals crossing_signals, previous_occupancies:
     """
 
@@ -60,5 +62,16 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
     light_signals[3] = not light_signals[2]
 
     crossing_signals[0] = train_in_e
-    return switch_positions, light_signals, crossing_signals
+
+    # if the switch position is in the wrong position 13-12 and there is a train in the off section
+    if not switch_positions[0] and train_in_a_b_c:
+        clamps[6:12] = [True]*len(clamps[6:12]) # clamp the blocks in c just in case
+    else:
+        clamps[6:12] = [False]*len(clamps[6:12])
+    # if the switch is in the wrong position 28-29 and there is a train in the section incoming
+    if not switch_positions[1] and train_in_y_z:
+        clamps[50:54] = [True]*len(clamps[50:54]) # clamp the blocks in y and z in case
+    else:
+        clamps[50:54] = [False]*len(clamps[50:54])
+    return switch_positions, light_signals, crossing_signals, clamps
     

--- a/src/Track/WaysideController/PLC/green_line_plc_2.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_2.py
@@ -59,9 +59,9 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
 
     # if switch position facing the yard and train in j
     if not switch_positions[1] and train_in_j:
-        clamps[22:27] = [True]*len(clamps[22:27])
+        clamps[25:27] = [True]*len(clamps[25:27])
     else:
-        clamps[22:27] = [False]*len(clamps[22:27])
+        clamps[25:27] = [False]*len(clamps[25:27])
 
     return switch_positions, light_signals, crossing_signals, clamps
 

--- a/src/Track/WaysideController/PLC/green_line_plc_2.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_2.py
@@ -62,6 +62,7 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
         clamps[25:27] = [True]*len(clamps[25:27])
     else:
         clamps[25:27] = [False]*len(clamps[25:27])
-
+    
+    
     return switch_positions, light_signals, crossing_signals, clamps
 

--- a/src/Track/WaysideController/PLC/green_line_plc_2.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_2.py
@@ -1,4 +1,4 @@
-def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signals, previous_occupancies, exit_blocks):
+def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signals, previous_occupancies, exit_blocks, clamps):
     """
     User-defined logic for controlling track switches.
 
@@ -57,5 +57,11 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
     light_signals[2] = switch_positions[1]
     light_signals[3] = not light_signals[2]
 
-    return switch_positions, light_signals, crossing_signals
+    # if switch position facing the yard and train in j
+    if not switch_positions[1] and train_in_j:
+        clamps[22:27] = [True]*len(clamps[22:27])
+    else:
+        clamps[22:27] = [False]*len(clamps[22:27])
+
+    return switch_positions, light_signals, crossing_signals, clamps
 

--- a/src/Track/WaysideController/PLC/green_line_plc_3.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_3.py
@@ -1,4 +1,4 @@
-def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signals, previous_occupancies, exit_blocks):
+def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signals, previous_occupancies, exit_blocks, clamps):
     """
     User-defined logic for controlling track switches.
 
@@ -46,16 +46,29 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
     train_in_m = any(block_occupancies[5:8])
     train_in_t = any(block_occupancies[36:41])
 
+
     switch_positions[0] = train_in_n
     light_signals[0] = not switch_positions[0]
     light_signals[2] = not light_signals[0]
 
 
-    switch_positions[1] = train_in_o_p_q and not (train_in_m and train_in_n)
+    switch_positions[1] = train_in_o_p_q and not train_in_n
     light_signals[1] = not switch_positions[1]
     light_signals[3] = not light_signals[1]
 
     crossing_signals[0] = train_in_t
 
-    return switch_positions, light_signals, crossing_signals
+    # switch to position 77-101 and train in m
+    if switch_positions[0] and train_in_m:
+        clamps[5:8] = [True]*len(clamps[5:8])
+    else:
+        clamps[5:8] = [False]*len(clamps[5:8])
+    
+    # switch to position 85-86 and there is a train in off section
+    if not switch_positions[1] and train_in_o_p_q:
+        clamps[29:32] = [True]*len(clamps[29:32])
+    else:
+        clamps[29:32] = [False]*len(clamps[29:32])
+
+    return switch_positions, light_signals, crossing_signals, clamps
 

--- a/src/Track/WaysideController/PLC/green_line_plc_3.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_3.py
@@ -60,9 +60,9 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
 
     # switch to position 77-101 and train in m
     if switch_positions[0] and train_in_m:
-        clamps[5:8] = [True]*len(clamps[5:8])
+        clamps[6:8] = [True]*len(clamps[6:8])
     else:
-        clamps[5:8] = [False]*len(clamps[5:8])
+        clamps[6:8] = [False]*len(clamps[6:8])
     
     # switch to position 85-86 and there is a train in off section
   #  if not switch_positions[1] and train_in_o_p_q:

--- a/src/Track/WaysideController/PLC/green_line_plc_3.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_3.py
@@ -64,11 +64,7 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
     else:
         clamps[6:8] = [False]*len(clamps[6:8])
     
-    # switch to position 85-86 and there is a train in off section
-  #  if not switch_positions[1] and train_in_o_p_q:
-    #    clamps[29:32] = [True]*len(clamps[29:32])
-    #else:
-     #   clamps[29:32] = [False]*len(clamps[29:32])
+  
 
     return switch_positions, light_signals, crossing_signals, clamps
 

--- a/src/Track/WaysideController/PLC/green_line_plc_3.py
+++ b/src/Track/WaysideController/PLC/green_line_plc_3.py
@@ -47,7 +47,7 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
     train_in_t = any(block_occupancies[36:41])
 
 
-    switch_positions[0] = train_in_n
+    switch_positions[0] = train_in_n or train_in_o_p_q
     light_signals[0] = not switch_positions[0]
     light_signals[2] = not light_signals[0]
 
@@ -65,10 +65,10 @@ def plc_logic(block_occupancies, switch_positions, light_signals, crossing_signa
         clamps[5:8] = [False]*len(clamps[5:8])
     
     # switch to position 85-86 and there is a train in off section
-    if not switch_positions[1] and train_in_o_p_q:
-        clamps[29:32] = [True]*len(clamps[29:32])
-    else:
-        clamps[29:32] = [False]*len(clamps[29:32])
+  #  if not switch_positions[1] and train_in_o_p_q:
+    #    clamps[29:32] = [True]*len(clamps[29:32])
+    #else:
+     #   clamps[29:32] = [False]*len(clamps[29:32])
 
     return switch_positions, light_signals, crossing_signals, clamps
 

--- a/src/Track/WaysideController/wayside_controller_collection.py
+++ b/src/Track/WaysideController/wayside_controller_collection.py
@@ -138,7 +138,7 @@ class WaysideControllerCollection(QObject):
         Called when the ctc dispatches a train. Verifies that it is safe to dispatch the train
         """
         if self.track_model != None:
-            if self.track_model.dynamic_track.occupancies["y151"] == Occupancy.UNOCCUPIED:
+            if self.track_model.dynamic_track.occupancies[self.track_model.track_data.SPAWN_BLOCK.id] == Occupancy.UNOCCUPIED:
                 self.track_model.initialize_train()
 
         

--- a/src/Train/TrainController/train_controller_backend.py
+++ b/src/Train/TrainController/train_controller_backend.py
@@ -307,6 +307,8 @@ class TrainController(QMainWindow):
             temp_authority = selected_data.get("wayside_authority", self.wayside_authority)
             if (temp_authority != 0 or self.wayside_authority == 0):
                 self.wayside_authority = temp_authority
+                if self.stop_asap and not self.manual_mode:
+                    self.emergency_brake = False
                 self.stop_asap = False
             else:
                 self.stop_asap = True

--- a/src/Train/TrainModel/train_model_backend.py
+++ b/src/Train/TrainModel/train_model_backend.py
@@ -204,9 +204,14 @@ class TrainModel(QMainWindow):
             self.wayside_authority = selected_data.get("wayside_authority", self.wayside_authority)
             if "wayside_authority" in selected_data.keys():
                 self.wayside_authority = selected_data["wayside_authority"]
+                if self.wayside_authority != 0:
+                    self.unclamped_authority = self.wayside_authority
                 authDict = {}
                 authDict["wayside_authority"] = self.wayside_authority
                 self.controller.set_input_data(train_model_data=authDict)
+            else:
+                print("Unclamping", self.unclamped_authority)
+                self.wayside_authority = self.unclamped_authority
             self.beacon_data = selected_data.get("beacon_data", self.beacon_data)
             grade = selected_data.get("grade", self.grade)
             if grade > 60:
@@ -240,6 +245,8 @@ class TrainModel(QMainWindow):
         data = {}
         data["actual_speed"] = self.actual_speed * self.MPS_TO_MPH
         data["wayside_speed"] = self.wayside_speed * self.MPS_TO_MPH
+        if self.wayside_authority == 0:
+            data["wayside_authority"] = 0
         data["beacon_data"] = self.beacon_data
         data["actual_temperature"] = (self.actual_temperature * 1.8) + 32
         data["signal_failure"] = self.signal_failure

--- a/src/Train/TrainModel/train_model_backend.py
+++ b/src/Train/TrainModel/train_model_backend.py
@@ -203,15 +203,19 @@ class TrainModel(QMainWindow):
             self.wayside_speed = selected_data.get("wayside_speed", self.wayside_speed*self.MPS_TO_MPH) / self.MPS_TO_MPH
             self.wayside_authority = selected_data.get("wayside_authority", self.wayside_authority)
             if "wayside_authority" in selected_data.keys():
-                self.wayside_authority = selected_data["wayside_authority"]
+                wayside_authority = selected_data["wayside_authority"]
+                if self.wayside_authority == None:
+                    print("Unclamping", self.unclamped_authority, "block", self.position)
+                    self.wayside_authority = self.unclamped_authority
+                else:
+                    self.wayside_authority = wayside_authority
                 if self.wayside_authority != 0:
                     self.unclamped_authority = self.wayside_authority
+                
                 authDict = {}
                 authDict["wayside_authority"] = self.wayside_authority
                 self.controller.set_input_data(train_model_data=authDict)
-            else:
-                print("Unclamping", self.unclamped_authority)
-                self.wayside_authority = self.unclamped_authority
+            
             self.beacon_data = selected_data.get("beacon_data", self.beacon_data)
             grade = selected_data.get("grade", self.grade)
             if grade > 60:

--- a/src/Train/TrainModel/train_model_backend.py
+++ b/src/Train/TrainModel/train_model_backend.py
@@ -207,14 +207,17 @@ class TrainModel(QMainWindow):
                 if self.wayside_authority == None:
                     print("Unclamping", self.unclamped_authority, "block", self.position)
                     self.wayside_authority = self.unclamped_authority
+                    authDict = {}
+                    self.controller.set_input_data(train_model_data=authDict)
                 else:
                     self.wayside_authority = wayside_authority
+                    authDict = {}
+                    authDict["wayside_authority"] = self.wayside_authority
+                    self.controller.set_input_data(train_model_data=authDict)
                 if self.wayside_authority != 0:
                     self.unclamped_authority = self.wayside_authority
                 
-                authDict = {}
-                authDict["wayside_authority"] = self.wayside_authority
-                self.controller.set_input_data(train_model_data=authDict)
+               
             
             self.beacon_data = selected_data.get("beacon_data", self.beacon_data)
             grade = selected_data.get("grade", self.grade)


### PR DESCRIPTION
makes it so that authority is clamped when a train approaches a switch that is facing the wrong direction. Does not clamp authority when trains are close yet.